### PR TITLE
Add (Values).Insert(k, v)

### DIFF
--- a/values.go
+++ b/values.go
@@ -19,6 +19,18 @@ func (v Values) Del(key string) { delete(v, key) }
 // Set assigns the given value for the key, erasing any other values held by it.
 func (v Values) Set(key, value string) { v[key] = []string{value} }
 
+// Insert inserts a value at the front of a list of values for the given key.
+func (v Values) Insert(key, value string) {
+	vals := v[key]
+	if len(vals) > 0 {
+		vals = append(vals[:1], vals...)
+		vals[0] = value
+	} else {
+		vals = []string{value}
+	}
+	v[key] = vals
+}
+
 // Getenv returns the first value held by the key. If the key is defined, but the slice is empty, it returns the empty
 // string. If the key is not set, it returns the empty string and ErrNoValue.
 func (v Values) Getenv(key string) (value string, err error) {

--- a/values_test.go
+++ b/values_test.go
@@ -13,6 +13,7 @@ func TestValuesMethods(t *testing.T) {
 		"a": {"zug", "zub"},
 		"b": {"quux"},
 		"c": {},
+		"d": {"7", "6", "5", "4", "3", "2", "1"},
 	}
 
 	values := make(Values)
@@ -27,6 +28,14 @@ func TestValuesMethods(t *testing.T) {
 	values.Set("b", "bar")
 	values.Set("b", "baz")
 	values.Set("b", "quux")
+
+	values.Insert("d", "1")
+	values.Insert("d", "2")
+	values.Insert("d", "3")
+	values.Insert("d", "4")
+	values.Insert("d", "5")
+	values.Insert("d", "6")
+	values.Insert("d", "7")
 
 	values["c"] = []string{}
 


### PR DESCRIPTION
This is useful mostly for ensuring that you can add new values that
take precedence over prior ones when adding values. Add already appends
values (useful for slices), but an equivalent is useful for simply
overriding stuff.