### PR TITLE
Fix pointer field assignment in loadStructField

### DIFF
--- a/issues_test.go
+++ b/issues_test.go
@@ -1,0 +1,51 @@
+package envi
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPointerFields(t *testing.T) { // issue #2
+	runner := func(env Env, dest interface{}, want interface{}) func(*testing.T) {
+		return func(t *testing.T) {
+
+			r := Reader{Source: env, Sep: "_"}
+			err := r.Getenv(dest, "Data")
+			if err != nil && !IsNoValue(err) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(dest, want) {
+				t.Fatalf("got\t%#+ v\nwant\t%#+ v", dest, want)
+			}
+		}
+	}
+
+	type Data struct {
+		Size int
+	}
+
+	type Value struct {
+		Value Data
+	}
+
+	type Pointer struct {
+		Value *Data
+	}
+
+	t.Run("HasEnv", func(t *testing.T) {
+		env := Values{"Data_Value_Size": {"16"}}
+		t.Run("StructValue", runner(env, new(Value), &Value{Value: Data{Size: 16}}))
+		t.Run("StructPointer", runner(env, new(Pointer), &Pointer{Value: &Data{Size: 16}}))
+		t.Run("StructValueAssigned", runner(env, &Value{Value: Data{Size: 32}}, &Value{Value: Data{Size: 16}}))
+		t.Run("StructPointerAssigned", runner(env, &Pointer{Value: &Data{Size: 32}}, &Pointer{Value: &Data{Size: 16}}))
+	})
+
+	t.Run("WithoutEnv", func(t *testing.T) {
+		env := Values{}
+		t.Run("StructValue", runner(env, new(Value), &Value{Value: Data{}}))
+		t.Run("StructPointer", runner(env, new(Pointer), &Pointer{Value: nil}))
+		t.Run("StructValueAssigned", runner(env, &Value{Value: Data{Size: 32}}, &Value{Value: Data{Size: 32}}))
+		t.Run("StructPointerAssigned", runner(env, &Pointer{Value: &Data{Size: 32}}, &Pointer{Value: &Data{Size: 32}}))
+	})
+}

--- a/reader.go
+++ b/reader.go
@@ -435,7 +435,10 @@ func (r *Reader) loadStructField(out reflect.Value, typ reflect.Type, fieldIdx i
 		dst    = target.Interface()
 	)
 
-	target.Elem().Set(field)
+	// Only copy field's value to temporary storage if it's valid
+	if fi := reflect.Indirect(field); fi.IsValid() {
+		target.Elem().Set(fi)
+	}
 	if err = r.Getenv(dst, fname); err != nil && !IsNoValue(err) && !flags.quiet {
 		return isset, err
 	}


### PR DESCRIPTION
- Wrap the field in indirect -- this more or less ensures the value
  being assigned is addressable and that a call to Elem() is safe.
  The indirect is wrapped in a reflect.Indirect specifically to perform
  an easy Elem-if-Ptr call.

- Add TestPointerFields test in issues_test.go -- issues_test.go is
  mostly intended to be a grab bag for collecting tests from issues.

Fixes #2.