### PR TITLE
Add GoDoc badge for godoc.org link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 envi
 ====
 
+[![GoDoc](https://godoc.org/github.com/Kochava/envi?status.svg)](https://godoc.org/github.com/Kochava/envi)
 [![Build Status](https://travis-ci.org/Kochava/envi.svg?branch=master)](https://travis-ci.org/Kochava/envi)
 [![Coverage Status](https://coveralls.io/repos/github/Kochava/envi/badge.svg)](https://coveralls.io/github/Kochava/envi)
 


### PR DESCRIPTION
This adds a godoc.org badge linking to the package's documentation on the site.